### PR TITLE
fix: build-mainnet-reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ start-server: # CTRL+C to stop
 	docker run -it --rm \
 		-p 9091:9091 -p 26657:26657 -p 26656:26656 -p 1317:1317 -p 5000:5000 \
 		-v $$(pwd):/root/code \
-		--name secretdev ghcr.io/scrtlabs/localsecret:v1.9.3
+		--name secretdev ghcr.io/scrtlabs/localsecret
 
 # This relies on running `start-server` in another console
 # You can run other commands on the secretcli inside the dev image

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build-mainnet-reproducible:
 	docker run --rm -v "$$(pwd)":/contract \
 		--mount type=volume,source="$$(basename "$$(pwd)")_cache",target=/contract/target \
 		--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-		ghcr.io/scrtlabs/localsecret:v1.6.0-rc.3
+		enigmampc/secret-contract-optimizer:1.0.10
 
 .PHONY: compress-wasm
 compress-wasm:
@@ -53,7 +53,7 @@ start-server: # CTRL+C to stop
 	docker run -it --rm \
 		-p 9091:9091 -p 26657:26657 -p 26656:26656 -p 1317:1317 -p 5000:5000 \
 		-v $$(pwd):/root/code \
-		--name secretdev ghcr.io/scrtlabs/localsecret:v1.6.0-rc.3
+		--name secretdev ghcr.io/scrtlabs/localsecret:v1.9.3
 
 # This relies on running `start-server` in another console
 # You can run other commands on the secretcli inside the dev image


### PR DESCRIPTION
This PR fixes a bug in the Makefile that runs localsecret when you try to build-mainnet-reproducible.